### PR TITLE
Node 15 and 16 compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [12, 14]
+        node: [12, 14, 15, 16]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 16
     - name: Publish
       run: |
         echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > ~/.npmrc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [12, 14]
+        node: [12, 14, 15, 16]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node: [12, 14]
+        node: [12, 14, 15, 16]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=8 <=14"
+    "node": ">=8 <=16"
   },
   "scripts": {
     "prebuild": "npm run clean",


### PR DESCRIPTION
Later this year, Node 16 will become the Active LTS. It is also the current only supported version of M1 Macs.

![https://nodejs.org/en/about/releases/](https://raw.githubusercontent.com/nodejs/Release/master/schedule.svg?sanitize=true)

I have taken in consideration the two existing pull requests and made the appropriate changes.
I ran all the tests with Node v16.0.0 on a M1 Mac and everything passed.
<details>
<summary>Logs</summary>

```zsh
~/.nvm/versions/node/v16.0.0/bin/node ~/.nvm/versions/node/v16.0.0/lib/node_modules/npm/bin/npm-cli.js test --scripts-prepend-node-path=auto

> concat-text-webpack-plugin@0.1.9 pretest
> npm run lint


> concat-text-webpack-plugin@0.1.9 lint
> eslint src/index.js test


> concat-text-webpack-plugin@0.1.9 test
> jest

 PASS  test/error.test.js
 PASS  test/plugin.test.js
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks.

Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
Snapshots:   54 passed, 54 total
Time:        3.012 s
Ran all test suites.
```

</details>